### PR TITLE
Fixed naming conflicts

### DIFF
--- a/ServiceManager.config
+++ b/ServiceManager.config
@@ -5,8 +5,8 @@
  * identical tomcat-users.xml files.
  */
 
-URL hex = new URL('http://grid.anc.org:9080/password/hex?length=16')
-URL password = new URL('http://grid.anc.org:9080/password/safe?length=16')
+URL hexService = new URL('http://grid.anc.org:9080/password/hex?length=16')
+URL passwordService = new URL('http://grid.anc.org:9080/password/safe?length=16')
 def config = new ConfigSlurper().parse(new File('service-manager.properties').text)
 Context {
 	displayName = config.display.name ?: "Lappsgrid"
@@ -14,16 +14,16 @@ Context {
 	// This likely doesn't need to be changed unless BPEL is running
 	// on a different machine.
 	activeBpelServicesUrl = 'http://localhost:8081/active-bpel/services'
-	
+
 	// This value is inserted into the service_manager.xml and
 	// active-bpel.xml files.
-	activeBpelAppAuthKey = "${hex.text}"
+	activeBpelAppAuthKey = "${hexService.text}"
 
 	// These values likely don't need to be changed.
 	maxCallNest = 16
 	atomicServiceReadTimeout = 30000
 	compositeServiceReadTimeout = 30000
-	
+
 }
 
 // The Tomcat configuration is used for both instances of tomcat.
@@ -31,15 +31,15 @@ Context {
 // edit the individual conf/tomcat-users.xml files.
 Tomcat {
 	rolename = 'serviceGridAdmin'
-	username = config.tomcat.username ?: "admin"
-	password = config.tomcat.password ?: "admin"
+	username = config.tomcat.username ?: "tomcat"
+	password = config.tomcat.password ?: passwordService.text
 }
 
 Database {
 	name = 'langrid'
 	table = 'langrid'
 	username = 'langrid'
-	password = password.text
+	password = passwordService.text
 }
 
 // Information for this node. Do all nodes in the LAPPS grid use the
@@ -48,7 +48,7 @@ Node {
 	gridId = 'lapps'
 	nodeId = config.node.id ?: "lapps"
 	name = config.node.name ?: "Lappsgrid"
-	url = 'http://localhost:8080/service_manager'
+	url = "http://localhost:${config.node.port ?: '8080'}/service_manager"
 	os = 'Unknown'
 	cpu = 'Unknown'
 	memory = 'Unknown'
@@ -63,11 +63,11 @@ Operator {
 	responsiblePerson = config.person ?: "Keith Suderman"
 	emailAddress = config.email ?: "suderman@cs.vassar.edu"
 	homepageUrl = config.url ?: "http://www.lappsgrid.org"
-	address = config.address ?: "New York"		
+	address = config.address ?: "New York"
 }
 
 Auth {
 	authIps = '127.0.0.1'
 	// Key inserted into bpr/langrid.ae.properties.
-	authKey = "${hex.text}"
+	authKey = "${hexService.text}"
 }

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 set -u
 
 smg=smg-1.1.0-SNAPSHOT
-service-manager=http://downloads.lappsgrid.org/service-manager
+manager=http://downloads.lappsgrid.org/service-manager
 scripts=http://downloads.lappsgrid.org/scripts
 
 function usage()
@@ -43,7 +43,7 @@ set -u
 
 # Edit the properties file first to get it out of the way and allow then
 # rest of the script to continue uninterrupted.
-wget $service-manager/service-manager.properties
+wget $manager/service-manager.properties
 $EDITOR service-manager.properties
 
 # Installs the packages required to install and run the Service Grid.
@@ -59,7 +59,7 @@ curl -sSL $scripts/install-postgres.sh | bash
 # to generate then Tomcat config files.
 log "Configuring the Service Manager"
 if [ ! -e ServiceManager.config ] ; then
-	wget $service-manager/ServiceManager.config
+	wget $manager/ServiceManager.config
 fi
 wget http://downloads.lappsgrid.org/$smg.tgz
 tar xzf $smg.tgz
@@ -82,7 +82,7 @@ cp langrid.ae.properties $BPEL/bpr
 source ./db.config
 
 log "Creating role, database and stored procedure."
-wget $service-manager/create_storedproc.sql
+wget $manager/create_storedproc.sql
 createuser -S -D -R $ROLENAME
 psql --command "ALTER USER $ROLENAME WITH PASSWORD '$PASSWORD'"
 createdb $DATABASE -O $ROLENAME -E 'UTF8'


### PR DESCRIPTION
The word *passport* was used in too many contexts and was confusing Groovy.