### PR TITLE
SQL script cleanup

### DIFF
--- a/database-setup.sh
+++ b/database-setup.sh
@@ -1,10 +1,9 @@
 createuser -S -D -R $ROLENAME
 psql --command "ALTER USER $ROLENAME WITH PASSWORD '$PASSWORD'"
 createdb $DATABASE -O $ROLENAME -E 'UTF8'
-createlang plpgsql $DATABASE
+#createlang plpgsql $DATABASE
 psql $DATABASE < /tmp/create_indices.sql
 psql $DATABASE < /tmp/create_storedproc.sql
 echo "ALTER FUNCTION \"AccessStat.increment\"(character varying, character varying, character varying, character varying, character varying, timestamp without time zone, timestamp without time zone, integer, timestamp without time zone, integer, timestamp without time zone, integer, integer, integer, integer) OWNER TO $ROLENAME" > /tmp/alter.sql
 psql $DATABSE < /tmp/alter.sql
-rm /tmp/*.sql
 #psql $DATABASE -c "ALTER FUNCTION \"AccessStat.increment\"(character varying, character varying, character varying, character varying, character varying, timestamp without time zone, timestamp without time zone, integer, timestamp without time zone, integer, timestamp without time zone, integer, integer, integer, integer) OWNER TO $ROLENAME"

--- a/setup.sh
+++ b/setup.sh
@@ -108,6 +108,7 @@ chmod +x /tmp/database-setup.sh
 mv *.sql /tmp
 # Now run the setup script as the postgres user.
 su - postgres -c "bash /tmp/database-setup.sh"
+rm /tmp*.sql
 
 log "Securing the Tomcat installations"
 for dir in $MANAGER $BPEL ; do


### PR DESCRIPTION
The /tmp/*.sql files are removed in setup.sh since the postgres user doesn't have rights. Also removed `createlang plpgsql`. 